### PR TITLE
[42기 황수영] ADD: 포스트 댓글 기능 구현

### DIFF
--- a/controllers/commentController.js
+++ b/controllers/commentController.js
@@ -1,0 +1,36 @@
+const commentService = require("../services/commentService");
+const { catchAsync } = require("../utils/errorHandler");
+
+const getComments = catchAsync(async (req, res) => {
+  const { postId } = req.params;
+
+  const data = await commentService.getComments(postId);
+
+  return res.status(200).json({ data });
+});
+
+const postComment = catchAsync(async (req, res) => {
+  const { postId } = req.params;
+  const { userId, content } = req.body;
+
+  if (!content) {
+    const error = new Error("KEY_ERROR");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  await commentService.postComment(postId, userId, content);
+
+  return res.status(201).json({ message: "success" });
+});
+
+const deleteComment = catchAsync(async (req, res) => {
+  const { commentId } = req.params;
+  const { userId } = req.body;
+
+  await commentService.deleteComment(commentId, userId);
+
+  return res.status(200).json({ message: "success" });
+});
+
+module.exports = { getComments, postComment, deleteComment };

--- a/models/commentDao.js
+++ b/models/commentDao.js
@@ -1,0 +1,65 @@
+const { appDataSource } = require("./appDataSource");
+
+const getComments = async (postId) => {
+  try {
+    return await appDataSource.query(
+      `SELECT
+        c.id AS commentId,
+        c.content,
+        c.post_id AS postId,
+        c.created_at AS createdAt,
+        u.id AS userId,
+        u.nickname,
+        u.profile_image AS profileImage
+      FROM comments c
+      LEFT JOIN users u ON u.id = c.user_id
+      WHERE c.post_id = ?
+      ORDER BY c.id DESC; 
+      `,
+      [postId]
+    );
+  } catch (err) {
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+const postComment = async (postId, userId, content) => {
+  try {
+    return await appDataSource.query(
+      `INSERT INTO comments
+        (
+          post_id,
+          user_id,
+          content
+        ) VALUES (?, ?, ?);
+      `,
+      [postId, userId, content]
+    );
+  } catch (err) {
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+const deleteComment = async (commentId, userId) => {
+  try {
+    const result = await appDataSource.query(
+      `DELETE FROM comments
+        WHERE id = ? AND user_id = ?;
+      `,
+      [commentId, userId]
+    );
+
+    if (result.affectedRows !== 1) {
+      const error = new Error("DELETE FAILED");
+      error.statusCode = 400;
+      throw error;
+    }
+  } catch (err) {
+    err.statusCode = 400;
+    throw err;
+  }
+};
+
+module.exports = { getComments, postComment, deleteComment };

--- a/routes/commentRouter.js
+++ b/routes/commentRouter.js
@@ -1,0 +1,10 @@
+const express = require("express");
+const router = express.Router();
+
+const commentController = require("../controllers/commentController");
+
+router.get("/post/:postId", commentController.getComments);
+router.post("/post/:postId", commentController.postComment);
+router.delete("/:commentId", commentController.deleteComment);
+
+module.exports = { router };

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,4 +4,8 @@ const postRouter = require("./postRouter");
 
 router.use("/posts", postRouter.router);
 
+const commentRouter = require("./commentRouter");
+
+router.use("/comments", commentRouter.router);
+
 module.exports = router;

--- a/services/commentService.js
+++ b/services/commentService.js
@@ -1,0 +1,15 @@
+const commentDao = require("../models/commentDao");
+
+const getComments = async (postId) => {
+  return await commentDao.getComments(postId);
+};
+
+const postComment = async (postId, userId, content) => {
+  return await commentDao.postComment(postId, userId, content);
+};
+
+const deleteComment = async (commentId, userId) => {
+  return await commentDao.deleteComment(commentId, userId);
+};
+
+module.exports = { getComments, postComment, deleteComment };

--- a/tests/comment.test.js
+++ b/tests/comment.test.js
@@ -1,0 +1,115 @@
+const request = require("supertest");
+const { createApp } = require("../app");
+const { appDataSource } = require("../models/appDataSource");
+const userFixture = require("./fixtures/user-fixtures");
+const postFixture = require("./fixtures/post-fixtures");
+const testUserData = require("./data/users");
+const testPostData = require("./data/posts");
+
+describe("COMMENT TEST", () => {
+  let app;
+
+  beforeAll(async () => {
+    app = createApp();
+    await appDataSource.initialize();
+    await userFixture.createUsers(testUserData.users);
+    await postFixture.createRoomStyles(testPostData.roomStyles);
+    await postFixture.createPosts(testPostData.posts);
+    await postFixture.createComments(testPostData.comments);
+  });
+
+  afterAll(async () => {
+    await appDataSource.query(`SET FOREIGN_KEY_CHECKS = 0`);
+    await appDataSource.query(`TRUNCATE comments`);
+    await appDataSource.query(`TRUNCATE posts`);
+    await appDataSource.query(`TRUNCATE room_styles`);
+    await appDataSource.query(`TRUNCATE users`);
+    await appDataSource.query(`SET FOREIGN_KEY_CHECKS = 1`);
+    await appDataSource.query(`ALTER TABLE comments AUTO_INCREMENT = 1`);
+    await appDataSource.destroy();
+  });
+
+  test("SUCCESS: GET COMMENTS BEFORE CREATING", async () => {
+    const res = await request(app).get("/comments/post/1");
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.data).toHaveLength(3);
+    expect(res.body.data).toEqual(getComments);
+  });
+
+  test("SUCCESS: COMMENT CREATED", async () => {
+    const res = await request(app)
+      .post("/comments/post/1")
+      .send({ userId: 1, content: "This is test comment" });
+
+    expect(res.statusCode).toEqual(201);
+    expect(res.body).toEqual({ message: "success" });
+  });
+
+  test("FAILED: CREATE COMMENT WITHOUT CONTENTS", async () => {
+    const res = await request(app).post("/comments/post/1").send({ userId: 1 });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toEqual({ message: "KEY_ERROR" });
+  });
+
+  test("SUCCESS: GET COMMENTS", async () => {
+    const res = await request(app).get("/comments/post/1");
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.data).toHaveLength(4);
+    expect(res.body.data[0].content).toEqual("This is test comment");
+  });
+
+  test("SUCCESS: DELETE COMMENT", async () => {
+    const res = await request(app).delete("/comments/4").send({ userId: 1 });
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toEqual({ message: "success" });
+  });
+
+  test("FAILED: DELETE COMMENT", async () => {
+    const res = await request(app).delete("/comments/4").send({ userId: 1 });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toEqual({ message: "DELETE FAILED" });
+  });
+
+  test("SUCCESS: GET COMMENTS", async () => {
+    const res = await request(app).get("/comments/post/1");
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.data).toHaveLength(3);
+    expect(res.body.data).toEqual(getComments);
+  });
+});
+
+const getComments = [
+  {
+    commentId: 3,
+    content: "테스트 댓글 3번",
+    userId: 3,
+    postId: 1,
+    nickname: "testUser03",
+    profileImage: "testProfileImage03.url",
+    createdAt: "2023-03-02T08:20:10.000Z",
+  },
+  {
+    commentId: 2,
+    content: "테스트 댓글 2번",
+    userId: 2,
+    postId: 1,
+    nickname: "testUser02",
+    profileImage: "testProfileImage02.url",
+    createdAt: "2023-03-01T08:26:39.000Z",
+  },
+  {
+    commentId: 1,
+    content: "테스트 댓글 1번",
+    userId: 1,
+    postId: 1,
+    nickname: "testUser01",
+    profileImage: "testProfileImage01.url",
+    createdAt: "2023-03-01T08:26:05.000Z",
+  },
+];

--- a/tests/data/posts.js
+++ b/tests/data/posts.js
@@ -214,10 +214,41 @@ const scarps = [
   },
 ];
 
+const comments = [
+  {
+    id: 1,
+    content: "테스트 댓글 1번",
+    user_id: 1,
+    post_id: 1,
+    comment_id: null,
+    created_at: "2023-03-01 17:26:05",
+    updated_at: null,
+  },
+  {
+    id: 2,
+    content: "테스트 댓글 2번",
+    user_id: 2,
+    post_id: 1,
+    comment_id: null,
+    created_at: "2023-03-01 17:26:39",
+    updated_at: null,
+  },
+  {
+    id: 3,
+    content: "테스트 댓글 3번",
+    user_id: 3,
+    post_id: 1,
+    comment_id: null,
+    created_at: "2023-03-02 17:20:10",
+    updated_at: null,
+  },
+];
+
 module.exports = {
   roomStyles,
   posts,
   postImages,
   imageCoordinate,
   scarps,
+  comments,
 };

--- a/tests/fixtures/post-fixtures.js
+++ b/tests/fixtures/post-fixtures.js
@@ -115,10 +115,42 @@ const createScraps = (scrapList) => {
   );
 };
 
+const createComments = (commentList) => {
+  const data = [];
+
+  for (const comment of commentList) {
+    data.push([
+      comment.id,
+      comment.content,
+      comment.user_id,
+      comment.post_id,
+      comment.comment_id,
+      comment.created_at,
+      comment.updated_at,
+    ]);
+  }
+
+  return appDataSource.query(
+    `
+    INSERT INTO comments (
+      id,
+      content,
+      user_id,
+      post_id,
+      comment_id,
+      created_at,
+      updated_at
+    ) VALUES ?
+  `,
+    [data]
+  );
+};
+
 module.exports = {
   createRoomStyles,
   createPosts,
   createPostImages,
   createImageCoordinates,
   createScraps,
+  createComments,
 };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- 포스트 댓글 작성, 조회, 삭제 기능 추가
<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- 포스트 댓글 조회 API 추가
- 댓글 작성 API 추가
- 댓글 삭제 API 추가

<br />

## :: 테스트 결과 이미지
1. Postman(Client Tool)을 이용한 API 테스트 결과 이미지
![스크린샷 2023-03-01 오후 5 25 43](https://user-images.githubusercontent.com/120305083/222086355-96336622-af89-4b97-976a-ed2b1ba13ec5.png)
![스크린샷 2023-03-01 오후 5 26 21](https://user-images.githubusercontent.com/120305083/222086333-b9230ff0-5529-41a7-a788-56f9182deac5.png)
![스크린샷 2023-03-01 오후 5 26 57](https://user-images.githubusercontent.com/120305083/222086310-f61f0f20-78cf-4f6a-80bc-8cc02e91d7e0.png)

3. 작성한 Test Code가 잘 통과했는지 확인할 수 있는 이미지
<img width="630" alt="스크린샷 2023-03-01 오후 5 23 06" src="https://user-images.githubusercontent.com/120305083/222086367-eb829cb3-0d1b-4fb2-b76a-1882ad9ffb77.png">

<br />

## :: 기타 질문 및 특이 사항
- 현재는 controller 단에서 userId를 req.body에서 받도록 되어 있는데, 로그인 기능 구현 후에 로그인 검증 미들웨어로부터 userId를 받도록 수정할 예정입니다.