### PR TITLE
[42기 박준우] ADD: 카카오 소셜 로그인 기능 구현과 유닛 테스트 작성 및 데이터베이스 유저 비밀번호 NULL로 바꿈

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,0 +1,19 @@
+const userService = require("../services/userService");
+const { catchAsync } = require("../utils/errorHandler");
+
+const kakaoLogin = catchAsync(async (req, res) => {
+  const kakaoToken = req.headers.authorization;
+
+  if (!kakaoToken) {
+    const error = new Error("KAKAOTOKEN IS NOT EXIST!");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const accessToken = await userService.kakaoLogin(kakaoToken);
+  return res.status(200).json({ accessToken: accessToken });
+});
+
+module.exports = {
+  kakaoLogin,
+};

--- a/db/migrations/20230301093642_create_users_modification_1.sql
+++ b/db/migrations/20230301093642_create_users_modification_1.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE users 
+  MODIFY COLUMN password varchar(200);
+
+-- migrate:down
+ALTER TABLE users
+  MODIFY COLUMN password varchar(200) NOT NULL;

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -1,0 +1,26 @@
+const jwt = require("jsonwebtoken");
+const catchAsync = require("../utils/errorHandler");
+
+const loginRequired = catchAsync(async (req, res, next) => {
+  const token = req.headers.authorization;
+  if (!token) {
+    const error = new Error("TOKEN IS NOT EXIST!");
+    error.statusCode = 400;
+    throw error;
+  }
+  const secretKey = process.env.SECRET_KET;
+  const decode = jwt.verify(token, secretKey);
+
+  if (!decode) {
+    const error = new Error("USERID IS NOT EXIST!");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  req.user = decode.id;
+  next();
+});
+
+module.exports = {
+  loginRequired,
+};

--- a/models/appDataSource.js
+++ b/models/appDataSource.js
@@ -9,15 +9,6 @@ const appDataSource = new DataSource({
   database: process.env.DB_DATABASE,
 });
 
-appDataSource
-  .initialize()
-  .then(() => {
-    console.log("Data server has been initiallized!!");
-  })
-  .catch((err) => {
-    console.log("Failed to connect database", err);
-  });
-
 module.exports = {
   appDataSource,
 };

--- a/models/userDao.js
+++ b/models/userDao.js
@@ -1,0 +1,50 @@
+const { appDataSource } = require("./appDataSource");
+
+const checkUserByKakaoId = async (kakaoId) => {
+  const result = await appDataSource.query(
+    `SELECT
+      u.social_id AS kakaoId
+    FROM users AS u
+    WHERE u.social_id = ?`,
+    [kakaoId]
+  );
+  return result;
+};
+
+const createUser = async (kakaoId, nickname, profileImage, email) => {
+  return await appDataSource.query(
+    `INSERT INTO
+      users(
+        social_id,
+        nickname,
+        profile_image,
+        email
+      ) VALUES(
+        ?,
+        ?,
+        ?,
+        ?
+      )`,
+    [kakaoId, nickname, profileImage, email]
+  );
+};
+
+const getUserBykakaoId = async (kakaoId) => {
+  const user = await appDataSource.query(
+    `SELECT
+      u.id,
+      u.nickname,
+      u.profile_image,
+      u.email
+    FROM users AS u
+    WHERE u.social_id = ?`,
+    [kakaoId]
+  );
+  return user;
+};
+
+module.exports = {
+  checkUserByKakaoId,
+  createUser,
+  getUserBykakaoId,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.3.4",
         "bcrypt": "^5.1.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
@@ -1406,8 +1407,17 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.4.3",
@@ -1924,7 +1934,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2057,7 +2066,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2384,11 +2392,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4499,6 +4525,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -6782,8 +6813,17 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "babel-jest": {
       "version": "29.4.3",
@@ -7142,7 +7182,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -7246,8 +7285,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -7500,11 +7538,15 @@
         "path-exists": "^4.0.0"
       }
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
     "form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -9091,6 +9133,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pstree.remy": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/wecode-bootcamp-korea/42-2nd-HomeAlone-backend#readme",
   "dependencies": {
+    "axios": "^1.3.4",
     "bcrypt": "^5.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,8 +4,10 @@ const postRouter = require("./postRouter");
 
 router.use("/posts", postRouter.router);
 
+const userRouter = require("./userRouter");
 const commentRouter = require("./commentRouter");
 
+router.use("/users", userRouter.router);
 router.use("/comments", commentRouter.router);
 
 module.exports = router;

--- a/routes/userRouter.js
+++ b/routes/userRouter.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const userController = require("../controllers/userController");
+
+const router = express.Router();
+
+router.post("/kakaoLogin", userController.kakaoLogin);
+
+module.exports = { router };

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 require("dotenv").config();
+const { appDataSource } = require("./models/appDataSource");
 
 const { createApp } = require("./app");
 
@@ -10,6 +11,15 @@ app.get("/ping", (req, res) => {
 
 const startServer = async () => {
   const PORT = process.env.PORT;
+
+  await appDataSource
+    .initialize()
+    .then(() => {
+      console.log("Data server has been initiallized!!");
+    })
+    .catch((err) => {
+      console.log("Failed to connect database", err);
+    });
 
   app.listen(PORT, () => {
     console.log(`server is listening on ${PORT}`);

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,0 +1,53 @@
+const userDao = require("../models/userDao");
+const jwt = require("jsonwebtoken");
+const axios = require("axios");
+
+const kakaoLogin = async (kakaoToken) => {
+  const kakaoResonse = await axios.get("https://kapi.kakao.com/v2/user/me", {
+    headers: {
+      authorization: `Bearer ${kakaoToken}`,
+      "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+    },
+  });
+
+  if (!kakaoResonse) {
+    const error = new Error("NO KAKAO USER INFORMATION!");
+    error.statusCode = 400;
+    throw error;
+  }
+  if (kakaoResonse.status !== 200) {
+    const error = new Error("KAKAOTOKEN IS INVALID!");
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const {
+    id: kakaoId,
+    kakao_account: {
+      profile: { nickname, profile_image_url: profileImage },
+      email,
+    },
+  } = kakaoResonse.data;
+
+  const checkKakaoUser = await userDao.checkUserByKakaoId(kakaoId);
+
+  if (checkKakaoUser.length === 0) {
+    const createUser = await userDao.createUser(
+      kakaoId,
+      nickname,
+      profileImage,
+      email
+    );
+  }
+
+  const user = await userDao.getUserBykakaoId(kakaoId);
+
+  const secretKey = process.env.SECRET_KET;
+  const payLoad = { userId: user.id };
+  const accessToken = jwt.sign(payLoad, secretKey);
+  return accessToken;
+};
+
+module.exports = {
+  kakaoLogin,
+};

--- a/tests/user.test.js
+++ b/tests/user.test.js
@@ -1,0 +1,86 @@
+const request = require("supertest");
+const axios = require("axios");
+
+const { createApp } = require("../app");
+const { appDataSource } = require("../models/appDataSource");
+
+jest.mock("axios");
+
+describe("KAKAO LOGIN", () => {
+  let app;
+
+  beforeAll(async () => {
+    app = createApp();
+    await appDataSource.initialize();
+  });
+
+  afterAll(async () => {
+    await appDataSource.query(`SET foreign_key_checks = 0`);
+    await appDataSource.query(`TRUNCATE users`);
+    await appDataSource.query(`SET foreign_key_checks = 1`);
+    await appDataSource.destroy();
+  });
+
+  test("FAILED: LOGIN FAIL DUE TO NO ACCESS TOKEN", async () => {
+    const response = await request(app).post("/users/kakaoLogin");
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toEqual({ message: "KAKAOTOKEN IS NOT EXIST!" });
+  });
+
+  test("SUCCESS: LOGIN SUCCESS WITH TOKEN", async () => {
+    axios.get = jest.fn().mockReturnValue({
+      status: 200,
+      data: {
+        id: 12345,
+        kakao_account: {
+          profile: {
+            profile_image_url: "profile_image1.png",
+            nickname: "nickname1",
+          },
+          email: "email1234@gmail.com",
+        },
+      },
+    });
+
+    const response = await request(app)
+      .post("/users/kakaoLogin")
+      .set({ authorization: "MOCK ACCESS TOKEN" });
+
+    expect(response.status).toEqual(200);
+    expect(response.body).toHaveProperty("accessToken");
+  });
+
+  test("FAILED: KAKAO USER INFOMATION IS NOT EXIST", async () => {
+    axios.get = jest.fn().mockReturnValue();
+    const response = await request(app)
+      .post("/users/kakaoLogin")
+      .set({ authorization: "MOCK ACCESS TOKEN" });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toEqual({ message: "NO KAKAO USER INFORMATION!" });
+  });
+
+  test("FAILED: KAKAOTOKEN IS INVALID!", async () => {
+    axios.get = jest.fn().mockReturnValue({
+      status: -401,
+      data: {
+        id: 12345,
+        kakao_account: {
+          profile: {
+            profile_image_url: "profile_image1.png",
+            nickname: "nickname1",
+          },
+          email: "email1234@gmail.com",
+        },
+      },
+    });
+
+    const response = await request(app)
+      .post("/users/kakaoLogin")
+      .set({ authorization: "MOCK ACCESS TOKEN" });
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toEqual({ message: "KAKAOTOKEN IS INVALID!" });
+  });
+});


### PR DESCRIPTION
[42기 박준우] ADD: 소셜 로그인,회원가입 기능구현 후 migration rebase main하러 감

[42기 박준우] ADD: 소셜 로그인,회원가입 기능, unit test 구현

[42기 박준우] ADD: 카카오 소셜 로그인 기능 구현과 유닛 테스트 작성

## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 데이터베이스 작업
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- 카카오 소셜 로그인, 회원가입 기능 구현 후 유닛 테스트

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- 카카오 소셜 로그인, 회원가입 기능 구현 후 유닛 테스트


<br />

## :: 테스트 결과 이미지
 Postman(Client Tool)을 이용한 API 테스트 결과 이미지
<img width="714" alt="스크린샷 2023-03-02 오후 6 44 10" src="https://user-images.githubusercontent.com/120322181/222391813-0fb7cafe-fe63-4dbc-921b-ce157833c8f6.png">
Unit Test 결과
<img width="702" alt="스크린샷 2023-03-02 오후 6 44 56" src="https://user-images.githubusercontent.com/120322181/222392010-202eab6b-953a-4d6a-b2b1-3dce10b2d38b.png">



<br />

## :: 기타 질문 및 특이 사항

