### PR TITLE
 [42기 황수영] FIX: 스크랩북 조회 시 반환 데이터에 유저 정보 추가

### DIFF
--- a/controllers/scrapController.js
+++ b/controllers/scrapController.js
@@ -19,9 +19,9 @@ const postScrap = catchAsync(async (req, res) => {
 const getScraps = catchAsync(async (req, res) => {
   const userId = req.user;
 
-  const data = await scrapService.getScraps(userId);
+  const { collections, user } = await scrapService.getScraps(userId);
 
-  return res.status(200).json({ data });
+  return res.status(200).json({ collections, user });
 });
 
 const deleteScrap = catchAsync(async (req, res) => {

--- a/models/userDao.js
+++ b/models/userDao.js
@@ -48,7 +48,8 @@ const getUserByUserId = async (userId) => {
     `SELECT
       id,
       nickname,
-      profile_image AS profileImage 
+      profile_image AS profileImage,
+      email
     FROM users 
     WHERE id = ?`,
     [userId]

--- a/models/userDao.js
+++ b/models/userDao.js
@@ -43,8 +43,23 @@ const getUserBykakaoId = async (kakaoId) => {
   return user;
 };
 
+const getUserByUserId = async (userId) => {
+  const [user] = await appDataSource.query(
+    `SELECT
+      id,
+      nickname,
+      profile_image AS profileImage 
+    FROM users 
+    WHERE id = ?`,
+    [userId]
+  );
+
+  return user;
+};
+
 module.exports = {
   checkUserByKakaoId,
   createUser,
   getUserBykakaoId,
+  getUserByUserId,
 };

--- a/services/scrapService.js
+++ b/services/scrapService.js
@@ -1,11 +1,15 @@
 const scrapDao = require("../models/scrapDao");
+const userDao = require("../models/userDao");
 
 const postScrap = async (postId, userId) => {
   return await scrapDao.postScrap(postId, userId);
 };
 
 const getScraps = async (userId) => {
-  return await scrapDao.getScraps(userId);
+  const collections = await scrapDao.getScraps(userId);
+  const user = await userDao.getUserByUserId(userId);
+
+  return { collections, user };
 };
 
 const deleteScrap = async (postId, userId) => {

--- a/tests/scrap.test.js
+++ b/tests/scrap.test.js
@@ -93,9 +93,14 @@ describe("SCRAP TEST", () => {
       .set("Authorization", accesstoken);
 
     expect(res.statusCode).toEqual(200);
-    expect(res.body.data).toEqual([
-      { id: 1, imageUrl: "postImage01.url", scrapId: 1 },
-    ]);
+    expect(res.body).toEqual({
+      collections: [{ id: 1, imageUrl: "postImage01.url", scrapId: 1 }],
+      user: {
+        id: 1,
+        nickname: "testUser01",
+        profileImage: "testProfileImage01.url",
+      },
+    });
   });
 
   test("FAILED: DELETE SCRAP - KEY ERROR", async () => {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- 스크랩북 조회 반환 데이터 변경

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- 스크랩북 조회 시 반환 데이터에 유저 정보 추가
- userDao.js 에 유저 정보를 조회하는 함수 추가
- 반환 데이터 형식 변경에 따른 테스트 케이스 기대값 변경

<br />

## :: 테스트 결과 이미지
![스크린샷 2023-03-09 오후 2 01 15](https://user-images.githubusercontent.com/120305083/223924558-cae7056f-2dfe-4442-816b-367fe6bb77e4.png)
![스크린샷 2023-03-09 오후 1 54 59](https://user-images.githubusercontent.com/120305083/223924600-03c02e06-8747-4554-9a1e-f45c83c5c864.png)


<br />

## :: 기타 질문 및 특이 사항